### PR TITLE
Issue #2: Added rebase functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/*
 docs/build/*
 .cache/*
 .flake8
+.pytest_cache/*

--- a/README.rst
+++ b/README.rst
@@ -34,3 +34,7 @@ To flatten alembic migrations, run the following command::
 To delete a specific revision, run the following command::
 
   $ ambix-prune <your-migration-directory> <id-of-revision-to-delete>
+
+To rebase a migration on different bases, run the following command:
+
+  $ ambix-rebase <your-migration-directory> <id-of-revision-to-rebase> <id-of-first-new-base> <id-of-second-new-base> ...

--- a/ambix/migration_script.py
+++ b/ambix/migration_script.py
@@ -12,6 +12,17 @@ class MigrationScript:
         self.down_revision = down_revision
         self.file_path = file_path
 
+    def get_down_revisions(self):
+        if self.down_revision is None:
+            return set()
+        elif (
+            isinstance(self.down_revision, collections.Iterable) and
+            not isinstance(self.down_revision, str)
+        ):
+            return set(self.down_revision)
+        else:
+            return set([self.down_revision])
+
     @classmethod
     def parse_file(cls, file_path):
         with AmbixError.handle_errors(
@@ -39,6 +50,8 @@ class MigrationScript:
 
         if len(new_down_revisions) == 1:
             new_down_revisions = new_down_revisions[0]
+        elif len(new_down_revisions) == 0:
+            new_down_revisions = None
 
         with AmbixError.handle_errors('failed while changing down revision'):
             with open(self.file_path) as script:

--- a/ambix/tools.py
+++ b/ambix/tools.py
@@ -24,3 +24,20 @@ def flatten(alembic_home_dir):
 def prune(alembic_home_dir, revision):
     home = MigrationHome(alembic_home_dir)
     home.prune(revision)
+
+
+@click.command()
+@click.argument(
+    'alembic-home-dir',
+    type=click.Path(exists=True),
+)
+@click.argument(
+    'revision',
+)
+@click.argument(
+    'new_bases',
+    nargs=-1,
+)
+def rebase(alembic_home_dir, revision, new_bases):
+    home = MigrationHome(alembic_home_dir)
+    home.rebase(revision, *new_bases)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'console_scripts': [
             'ambix-flatten = ambix.tools:flatten',
             'ambix-prune = ambix.tools:prune',
+            'ambix-rebase = ambix.tools:rebase',
         ],
     },
 )


### PR DESCRIPTION
Added the ability to rebase a specific migration to a new set of bases.
This could be used to re-position a migration at the end or whatever
else.

Also fixed a bug I hadn't noticed in pruning where if a migration was
pruned with multiple down_migrations, any nodes that had the deleted
migration as a down_migration would not get the full set of
down_migrations

Added entry point executable and tets for the new stuff